### PR TITLE
release: 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ dependencies = [
 
 [[package]]
 name = "wdpe"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "custom_debug_derive",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "wdpe-macros"]
 
 [package]
 name = "wdpe"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "WebDynpro Parse Engine"
 keywords = ["webdynpro", "sap", "scraping", "parser"]


### PR DESCRIPTION
## Summary
- Bump version to 0.4.3

## Changes since 0.4.2
- feat(reqwest): make rustls TLS backend configurable via features (#22)
  - Added `reqwest-rustls` and `reqwest-rustls-no-provider` features

## Test plan
- [x] `cargo check --features reqwest-rustls` passes
- [x] `cargo check --features reqwest-rustls-no-provider` passes